### PR TITLE
security: use explicit fields in profile DTO instead of index signature

### DIFF
--- a/modules/api/src/routes/auth/auth.controller.ts
+++ b/modules/api/src/routes/auth/auth.controller.ts
@@ -45,7 +45,15 @@ export class AuthController {
   getProfile(
     @Session() session: UserSession,
   ): ProfileResponseDto {
-    return session.user;
+    const { id, name, email, image, createdAt, updatedAt } = session.user;
+    return {
+      id,
+      name,
+      email,
+      image: image ?? undefined,
+      createdAt: createdAt instanceof Date ? createdAt.toISOString() : String(createdAt),
+      updatedAt: updatedAt instanceof Date ? updatedAt.toISOString() : String(updatedAt),
+    };
   }
 
   @Get('session-claims')

--- a/modules/api/src/routes/auth/dto/profile-response.dto.ts
+++ b/modules/api/src/routes/auth/dto/profile-response.dto.ts
@@ -1,5 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { ProfileResponseDto as ProfileResponseDtoShape } from '@librestock/types';
 
 export class ProfileResponseDto implements ProfileResponseDtoShape {
-  [key: string]: unknown;
+  @ApiProperty({ description: 'User ID' })
+  id: string;
+
+  @ApiProperty({ description: 'User display name' })
+  name: string;
+
+  @ApiProperty({ description: 'User email address' })
+  email: string;
+
+  @ApiPropertyOptional({ description: 'User avatar URL' })
+  image?: string;
+
+  @ApiProperty({ description: 'Account creation timestamp', format: 'date-time' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Account last updated timestamp', format: 'date-time' })
+  updatedAt: string;
 }

--- a/packages/types/src/auth/profile-response.type.ts
+++ b/packages/types/src/auth/profile-response.type.ts
@@ -1,3 +1,8 @@
 export interface ProfileResponseDto {
-  [key: string]: unknown
+  id: string
+  name: string
+  email: string
+  image?: string
+  createdAt: string
+  updatedAt: string
 }


### PR DESCRIPTION
This pull request refactors the user profile response shape for authentication endpoints to provide a more explicit and type-safe structure. The changes introduce a strongly typed `ProfileResponseDto`, update its usage in the API controller, and enhance API documentation with Swagger decorators.

**Profile response type improvements:**

* Defined explicit fields (`id`, `name`, `email`, `image`, `createdAt`, `updatedAt`) in the `ProfileResponseDto` interface, replacing the previous generic object type (`[key: string]: unknown`) in `profile-response.type.ts`.
* Updated the `ProfileResponseDto` class in `profile-response.dto.ts` to match the new interface and added Swagger decorators for better API documentation.

**Controller logic updates:**

* Modified the `getProfile` method in `auth.controller.ts` to return the new explicit profile shape, ensuring correct typing and string conversion for timestamps.Replace open [key: string]: unknown with explicit field list to prevent leaking internal auth data from the session object.

Closes #144