### PR TITLE
security: add helmet middleware and body parser size limits

### DIFF
--- a/modules/api/package.json
+++ b/modules/api/package.json
@@ -23,6 +23,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@librestock/types": "workspace:*",
     "@nestjs/common": "^11.1.10",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.10",
@@ -37,12 +38,12 @@
     "class-validator": "^0.14.3",
     "csv-parse": "^6.1.0",
     "dotenv": "^16.6.1",
+    "helmet": "^8.1.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "typeorm": "^0.3.28",
-    "uuid": "^13.0.0",
-    "@librestock/types": "workspace:*"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.1.0",

--- a/modules/api/src/main.ts
+++ b/modules/api/src/main.ts
@@ -2,6 +2,8 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import helmet from 'helmet';
+import * as express from 'express';
 import { AppModule } from './app.module';
 import { auth } from './auth';
 import { Client } from './clients/entities/client.entity';
@@ -34,6 +36,13 @@ async function bootstrap() {
   });
   const configService = app.get(ConfigService);
   const logger = new Logger('Bootstrap');
+
+  app.use(helmet({
+    contentSecurityPolicy: isProduction ? undefined : false,
+  }));
+
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
   const corsOrigin = configService.get<string>('CORS_ORIGIN');
   if (isProduction && (!corsOrigin || corsOrigin === '*')) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -4869,6 +4872,10 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -12243,6 +12250,8 @@ snapshots:
       function-bind: 1.1.2
 
   headers-polyfill@4.0.3: {}
+
+  helmet@8.1.0: {}
 
   hermes-estree@0.25.1: {}
 


### PR DESCRIPTION
Add helmet for HTTP security headers and configure express body parser with 10mb size limits to prevent large payload abuse.

Closes #141, Closes #142