### PR TITLE
fix: load dotenv before NODE_ENV validation and add migration flag

### DIFF
--- a/modules/api/src/main.ts
+++ b/modules/api/src/main.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory, Reflector } from '@nestjs/core';
@@ -100,8 +101,8 @@ async function bootstrap() {
     logger.log('Swagger UI enabled at /api/docs');
   }
 
-  // Run Better Auth migrations in non-production (mirrors TypeORM synchronize behavior)
-  if (!isProduction) {
+  // Run Better Auth migrations in non-production, or when explicitly requested via env flag
+  if (!isProduction || process.env.RUN_BETTER_AUTH_MIGRATIONS === 'true') {
     const ctx = await auth.$context;
     await ctx.runMigrations();
   }


### PR DESCRIPTION
## Summary
- Load `dotenv/config` at the top of `main.ts` so `.env` values (including `NODE_ENV`) are available before validation runs
- Add `RUN_BETTER_AUTH_MIGRATIONS=true` env flag to allow running Better Auth migrations in production deployments

Addresses Copilot review feedback from #157.

## Test plan
- [ ] Verify `.env` file `NODE_ENV` value is respected
- [ ] Verify `RUN_BETTER_AUTH_MIGRATIONS=true` triggers migration run in production mode
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)